### PR TITLE
workflow now makes pr instead of pushing to master

### DIFF
--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -88,7 +88,7 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -X GET \
           --jq '.[] | .number')
-          for i in ${MILESTONE_NAMES[@]}
+          for i in ${!MILESTONE_NAMES[@]}
           do
             if [[ ${MILESTONE_NAMES[$i]} == ${{ env.NEW_RELEASE_VERSION }} ]]
             then
@@ -120,7 +120,7 @@ jobs:
           title: "[INIT] Update `version.py` and create release notes for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
-          milestone: env.MILESTONE_NUMBER
+          milestone: ${{ env.MILESTONE_NUMBER }}
           labels: |
             Priority:1-Critical
             Status:5-In Review
@@ -145,7 +145,7 @@ jobs:
           title: "[REQUIRED FOR PUBLISHING] Finishing touches for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Merging this PR is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
-          milestone: env.MILESTONE_NUMBER
+          milestone: ${{ env.MILESTONE_NUMBER }}
           labels: |
             Priority:2-Normal
             Status:1-New

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -73,7 +73,6 @@ jobs:
             -X POST \
             -F title=${{ env.NEW_RELEASE_VERSION }} 
           fi
-          
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -96,9 +95,9 @@ jobs:
               INDEX=$i
             fi
           done
+          echo "MILESTONE_NUMBER="${MILESTONE_NUMBERS[$INDEX]} >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
- echo "MILESTONE_NUMBER="${MILESTONE_NUMBERS[$INDEX]} >> $GITHUB_ENV
 
       - name: "Make initial changes for ${{ env.NEW_RELEASE_VERISON }}"
         run: |

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -78,33 +78,23 @@ jobs:
 
       - name: Update version.py
         run: |
-          echo "Configure git"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          echo "Make edits to version.py"
           sed -i "s/_version_micro = '*[0-9]*'*/_version_micro = ''/g" saltproc/version.py
           sed -i "s/_version_minor = [0-9]*/_version_minor = ${{ env.MINOR_VERSION }}/g" saltproc/version.py
           sed -i "s/^# _version_extra = 'dev'/_version_extra = 'dev'/g" saltproc/version.py
           sed -i "s/^_version_extra = '0'/# _version_extra = '0'/g" saltproc/version.py
-          echo "Add, commit, and push changes"
-          git add saltproc/version.py 
-          git commit -m "updated version to ${{ env.NEW_RELEASE_VERSION }}-dev"
-          git push origin HEAD:master
-
 
       - name: Create new release notes
         run: |
-          echo "Configure git"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          echo "Make edits to docfiles"
           sed -i "s/\.\. note:: These release notes are currently in production\.//g" doc/releasenotes/${{ env.RELEASE_VERSION }}.rst
           cp doc/releasenotes/template.rst doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/vx.x.x/${{ env.NEW_RELEASE_VERSION }}/g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/${{ env.RELEASE_VERSION }}/${{ env.NEW_RELEASE_VERSION }}\n  ${{ env.RELEASE_VERSION }}/g" doc/releasenotes/index.rst
-          echo "Add, commit, and push changes"
-          git add doc/releasenotes/${{ env.RELEASE_VERSION }}.rst
-          git add doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
-          git add doc/releasenotes/index.rst
-          git commit -m "created ${{ env.NEW_RELEASE_VERSION }} release notes"
-          git push origin HEAD:master
+
+      - name: Create PR for changes
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: "${{ env.NEW_RELEASE_VERSION }}-init"
+          commit-message: "update files for ${{ env.NEW_RELEASE_VERSION }}"
+          title: "Initialize ${{ env.NEW_RELEAES_VERISION }}"
+          body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."
+          reviewers: ["yardasol"]

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -77,6 +77,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: "Get milestone number for ${{ env.NEW_RELEASE_VERSION }}"
+        run: |
+          mapfile -t MILESTONE_NAMES < <(gh api repos/${{ github.repository }}/milestones \
+          -H "Authorize: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -X GET \
+          --jq '.[] | .title')
+          mapfile -t MILESTONE_NUMBERS < <(gh api repos/${{ github.repository }}/milestones \
+          -H "Authorize: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -X GET \
+          --jq '.[] | .number')
+          for i in ${MILESTONE_NAMES[@]}
+          do
+            if [[ ${MILESTONE_NAMES[$i]} == ${{ env.NEW_RELEASE_VERSION }} ]]
+            then
+              INDEX=$i
+            fi
+          done
+          echo "MILESTONE_NUMBER="${MILESTONE_NUMBERS[$INDEX]} >> $GITHUB_ENV
+
       - name: "Make initial changes for ${{ env.NEW_RELEASE_VERISON }}"
         run: |
           echo "Update version.py"
@@ -98,6 +119,7 @@ jobs:
           title: "[INIT] Update `version.py` and create release notes for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
+          milestone: env.MILESTONE_NUMBER
           labels: |
             Priority:1-Critical
             Status:5-In Review
@@ -122,6 +144,7 @@ jobs:
           title: "[REQUIRED FOR PUBLISHING] Finishing touches for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Merging this PR is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
+          milestone: env.MILESTONE_NUMBER
           labels: |
             Priority:2-Normal
             Status:1-New

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Initial changes for the new version
+      - name: Make initial changes for version env.NEW_RELEASE_VERISON 
         run: |
           echo "Update version.py"
           sed -i "s/_version_micro = '*[0-9]*'*/_version_micro = ''/g" saltproc/version.py
@@ -89,29 +89,29 @@ jobs:
           sed -i "s/vx.x.x/${{ env.NEW_RELEASE_VERSION }}/g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/${{ env.RELEASE_VERSION }}/${{ env.NEW_RELEASE_VERSION }}\n  ${{ env.RELEASE_VERSION }}/g" doc/releasenotes/index.rst
 
-      - name: Create PR for inital new version changes
+      - name: Create PR containing inital changes for version env.NEW_RELEASE_VERSION 
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
           delete-branch: true
-          commit-message: "initialize files for ${{ env.NEW_RELEASE_VERSION }}"
-          title: "Initialize ${{ env.NEW_RELEASE_VERSION }}"
-          body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."
+          commit-message: "inital changes for ${{ env.NEW_RELEASE_VERSION }}"
+          title: "[INIT] Update `version.py` and create release notes for version {{ env.NEW_RELEASE_VERSION }}"
+          body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
 
-      - name: Advance changes for publishing the new release
+      - name: Make changes necessary for publishing version env.NEW_RELEASE_VERSION in advance
         run: |
           sed -i "s/\.\. note:: These release notes are currently in production\.//g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/^_version_extra = 'dev'/# _version_extra = 'dev'/g" saltproc/version.py
           sed -i "s/# _version_extra = '0'/_version_extra = '0'/g" saltproc/version.py
 
-      - name: Create advance PR final new version changes
+      - name: Create PR containing changes necessary for publishing env.NEW_RELEASE_VERSION
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-final"
           base: master
           delete-branch: true
-          commit-message: "update version.py and the release notes before publishing ${{ env.NEW_RELEASE_VERSION }}"
-          title: "Finalize ${{ env.NEW_RELEASE_VERSION }}"
-          body: "MERGE BEFORE PUBLISHING ${{ env.NEW_RELEASE_VERSION }}.\n This is an automated PR that updates version for the full release of the in-develpoment version of the software."
+          commit-message: "final changes before publishing ${{ env.NEW_RELEASE_VERSION }}"
+          title: "[REQUIRED FOR PUBLISHING] Finishing touches for version ${{ env.NEW_RELEASE_VERSION }}"
+          body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Merging this PR is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -76,26 +76,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update version.py
+      - name: Initial changes for the new version
         run: |
+          echo "Update version.py"
           sed -i "s/_version_micro = '*[0-9]*'*/_version_micro = ''/g" saltproc/version.py
           sed -i "s/_version_minor = [0-9]*/_version_minor = ${{ env.MINOR_VERSION }}/g" saltproc/version.py
           sed -i "s/^# _version_extra = 'dev'/_version_extra = 'dev'/g" saltproc/version.py
           sed -i "s/^_version_extra = '0'/# _version_extra = '0'/g" saltproc/version.py
-
-      - name: Create new release notes
-        run: |
-          sed -i "s/\.\. note:: These release notes are currently in production\.//g" doc/releasenotes/${{ env.RELEASE_VERSION }}.rst
+          echo "Create new release notes"
           cp doc/releasenotes/template.rst doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/vx.x.x/${{ env.NEW_RELEASE_VERSION }}/g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/${{ env.RELEASE_VERSION }}/${{ env.NEW_RELEASE_VERSION }}\n  ${{ env.RELEASE_VERSION }}/g" doc/releasenotes/index.rst
 
-      - name: Create PR for changes
+      - name: Create PR for inital new version changes
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
           delete-branch: true
-          commit-message: "update files for ${{ env.NEW_RELEASE_VERSION }}"
+          commit-message: "initialize files for ${{ env.NEW_RELEASE_VERSION }}"
           title: "Initialize ${{ env.NEW_RELEASE_VERISION }}"
           body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."
+          reviewers: yardasol
+
+      - name: Advance changes for publishing the new release
+        run: |
+          sed -i "s/\.\. note:: These release notes are currently in production\.//g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
+          sed -i "s/^_version_extra = 'dev'/# _version_extra = 'dev'/g" saltproc/version.py
+          sed -i "s/# _version_extra = '0'/_version_extra = '0'/g" saltproc/version.py
+
+      - name: Create advance PR final new version changes
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: "${{ env.NEW_RELEASE_VERSION }}-final"
+          delete-branch: true
+          commit-message: "update version.py and the release notes before publishing ${{ env.NEW_RELEASE_VERSION }}"
+          title: "Finalize ${{ env.NEW_RELEASE_VERISION }}"
+          body: "MERGE BEFORE PUBLISHING ${{ env.NEW_RELEASE_VERSION }}.\n This is an automated PR that updates version for the full release of the in-develpoment version of the software."
           reviewers: yardasol

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -95,6 +95,6 @@ jobs:
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
           commit-message: "update files for ${{ env.NEW_RELEASE_VERSION }}"
-          title: "Initialize ${{ env.NEW_RELEAES_VERISION }}"
+          title: "Initialize ${{ env.NEW_RELEASE_VERISION }}"
           body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."
           reviewers: yardasol

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -143,7 +143,7 @@ jobs:
           delete-branch: true
           commit-message: "final changes before publishing ${{ env.NEW_RELEASE_VERSION }}"
           title: "[REQUIRED FOR PUBLISHING] Finishing touches for version ${{ env.NEW_RELEASE_VERSION }}"
-          body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Merging this PR is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}"
+          body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Rebasing this PR on top of the most recent commit in `master` is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}. We rebase becasue the commits in this PR were created around the same time development on ${{ env.NEW_RELEASE_VERSION }} began."
           reviewers: yardasol
           milestone: ${{ env.MILESTONE_NUMBER }}
           labels: |

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -95,7 +95,7 @@ jobs:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
           delete-branch: true
           commit-message: "inital changes for ${{ env.NEW_RELEASE_VERSION }}"
-          title: "[INIT] Update `version.py` and create release notes for version {{ env.NEW_RELEASE_VERSION }}"
+          title: "[INIT] Update `version.py` and create release notes for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
 
@@ -105,7 +105,7 @@ jobs:
           sed -i "s/^_version_extra = 'dev'/# _version_extra = 'dev'/g" saltproc/version.py
           sed -i "s/# _version_extra = '0'/_version_extra = '0'/g" saltproc/version.py
 
-      - name: Create PR containing changes necessary for publishing env.NEW_RELEASE_VERSION
+      - name: "Create PR containing changes necessary for publishing ${{ env.NEW_RELEASE_VERSION }}"
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-final"

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -94,7 +94,7 @@ jobs:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
           delete-branch: true
           commit-message: "initialize files for ${{ env.NEW_RELEASE_VERSION }}"
-          title: "Initialize ${{ env.NEW_RELEASE_VERISION }}"
+          title: "Initialize ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."
           reviewers: yardasol
 
@@ -110,6 +110,6 @@ jobs:
           branch: "${{ env.NEW_RELEASE_VERSION }}-final"
           delete-branch: true
           commit-message: "update version.py and the release notes before publishing ${{ env.NEW_RELEASE_VERSION }}"
-          title: "Finalize ${{ env.NEW_RELEASE_VERISION }}"
+          title: "Finalize ${{ env.NEW_RELEASE_VERSION }}"
           body: "MERGE BEFORE PUBLISHING ${{ env.NEW_RELEASE_VERSION }}.\n This is an automated PR that updates version for the full release of the in-develpoment version of the software."
           reviewers: yardasol

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -92,6 +92,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
+          base: "master"
           delete-branch: true
           commit-message: "initialize files for ${{ env.NEW_RELEASE_VERSION }}"
           title: "Initialize ${{ env.NEW_RELEASE_VERSION }}"
@@ -108,6 +109,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-final"
+          base: "master"
           delete-branch: true
           commit-message: "update version.py and the release notes before publishing ${{ env.NEW_RELEASE_VERSION }}"
           title: "Finalize ${{ env.NEW_RELEASE_VERSION }}"

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -73,6 +73,7 @@ jobs:
             -X POST \
             -F title=${{ env.NEW_RELEASE_VERSION }} 
           fi
+          
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -108,6 +109,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-final"
+          base: master
           delete-branch: true
           commit-message: "update version.py and the release notes before publishing ${{ env.NEW_RELEASE_VERSION }}"
           title: "Finalize ${{ env.NEW_RELEASE_VERSION }}"

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -97,4 +97,4 @@ jobs:
           commit-message: "update files for ${{ env.NEW_RELEASE_VERSION }}"
           title: "Initialize ${{ env.NEW_RELEAES_VERISION }}"
           body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."
-          reviewers: ["yardasol"]
+          reviewers: yardasol

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -98,6 +98,13 @@ jobs:
           title: "[INIT] Update `version.py` and create release notes for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
+          labels: |
+            "Priority:1-Critical"
+            "Status:5-In Review"
+            "Type:Style"
+            "Type:Docs"
+            "Difficulty:1-Beginner"
+            "Comp:Build"
 
       - name: "Make changes necessary for publishing ${{ env.NEW_RELEASE_VERSION }} in advance"
         run: |
@@ -115,3 +122,11 @@ jobs:
           title: "[REQUIRED FOR PUBLISHING] Finishing touches for version ${{ env.NEW_RELEASE_VERSION }}"
           body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Merging this PR is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
+          labels: |
+            "Priority:2-Normal"
+            "Status:1-New"
+            "Type:Style"
+            "Type:Docs"
+            "Difficulty:1-Beginner"
+            "Comp:Build"
+

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -96,7 +96,9 @@ jobs:
               INDEX=$i
             fi
           done
-          echo "MILESTONE_NUMBER="${MILESTONE_NUMBERS[$INDEX]} >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ echo "MILESTONE_NUMBER="${MILESTONE_NUMBERS[$INDEX]} >> $GITHUB_ENV
 
       - name: "Make initial changes for ${{ env.NEW_RELEASE_VERISON }}"
         run: |

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -92,7 +92,6 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
-          base: "master"
           delete-branch: true
           commit-message: "initialize files for ${{ env.NEW_RELEASE_VERSION }}"
           title: "Initialize ${{ env.NEW_RELEASE_VERSION }}"
@@ -109,7 +108,6 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-final"
-          base: "master"
           delete-branch: true
           commit-message: "update version.py and the release notes before publishing ${{ env.NEW_RELEASE_VERSION }}"
           title: "Finalize ${{ env.NEW_RELEASE_VERSION }}"

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -34,7 +34,7 @@ jobs:
           echo "MINOR_VERSION="$MINOR_VERSION >> $GITHUB_ENV
           echo "NEW_RELEASE_VERSION="$NEW_RELEASE_VERSION >> $GITHUB_ENV
 
-      - name: Check for existing release
+      - name: "Check for existing ${{ env.NEW_RELEASE_VERSION }} draft release"
         run: |
           RELEASES=$(gh api repos/${{ github.repository }}/releases \
           -H "Authorize: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for existing milestone
+      - name: "Check for existing ${{ env.NEW_RELEASE_VERSION }} milestone"
         run: |
           MILESTONES=$(gh api repos/${{ github.repository }}/milestones \
           -H "Authorize: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -77,7 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Make initial changes for version env.NEW_RELEASE_VERISON 
+      - name: "Make initial changes for ${{ env.NEW_RELEASE_VERISON }}"
         run: |
           echo "Update version.py"
           sed -i "s/_version_micro = '*[0-9]*'*/_version_micro = ''/g" saltproc/version.py
@@ -89,7 +89,7 @@ jobs:
           sed -i "s/vx.x.x/${{ env.NEW_RELEASE_VERSION }}/g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/${{ env.RELEASE_VERSION }}/${{ env.NEW_RELEASE_VERSION }}\n  ${{ env.RELEASE_VERSION }}/g" doc/releasenotes/index.rst
 
-      - name: Create PR containing inital changes for version env.NEW_RELEASE_VERSION 
+      - name: "Create PR containing inital changes for ${{ env.NEW_RELEASE_VERSION }}" 
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
@@ -99,7 +99,7 @@ jobs:
           body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
 
-      - name: Make changes necessary for publishing version env.NEW_RELEASE_VERSION in advance
+      - name: "Make changes necessary for publishing ${{ env.NEW_RELEASE_VERSION }} in advance"
         run: |
           sed -i "s/\.\. note:: These release notes are currently in production\.//g" doc/releasenotes/${{ env.NEW_RELEASE_VERSION }}.rst
           sed -i "s/^_version_extra = 'dev'/# _version_extra = 'dev'/g" saltproc/version.py

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -94,6 +94,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           branch: "${{ env.NEW_RELEASE_VERSION }}-init"
+          delete-branch: true
           commit-message: "update files for ${{ env.NEW_RELEASE_VERSION }}"
           title: "Initialize ${{ env.NEW_RELEASE_VERISION }}"
           body: "This is an automated PR that updates the version and add release note for the new in-develpoment version of the software."

--- a/.github/workflows/next-release-minor.yml
+++ b/.github/workflows/next-release-minor.yml
@@ -99,12 +99,12 @@ jobs:
           body: "This is an automated PR that updates the version number and creates the release notes file for version ${{ env.NEW_RELEASE_VERSION }}. This should be the first PR merged during development of version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
           labels: |
-            "Priority:1-Critical"
-            "Status:5-In Review"
-            "Type:Style"
-            "Type:Docs"
-            "Difficulty:1-Beginner"
-            "Comp:Build"
+            Priority:1-Critical
+            Status:5-In Review
+            Type:Style
+            Type:Docs
+            Difficulty:1-Beginner
+            Comp:Build
 
       - name: "Make changes necessary for publishing ${{ env.NEW_RELEASE_VERSION }} in advance"
         run: |
@@ -123,10 +123,10 @@ jobs:
           body: "This is an automated PR that updates the version number and release notes in preparation for the full release of version ${{ env.NEW_RELEASE_VERSION }}. This should be last PR merged before publishing version ${{ env.NEW_RELEASE_VERSION }}. Merging this PR is a prequisite of publishing version ${{ env.NEW_RELEASE_VERSION }}"
           reviewers: yardasol
           labels: |
-            "Priority:2-Normal"
-            "Status:1-New"
-            "Type:Style"
-            "Type:Docs"
-            "Difficulty:1-Beginner"
-            "Comp:Build"
+            Priority:2-Normal
+            Status:1-New
+            Type:Style
+            Type:Docs
+            Difficulty:1-Beginner
+            Comp:Build
 


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
This PR addresses #135. Specifically this PR makes the `next-release-minor.yml` workflow create a new PR instead of pushing directly to master.

Do not merge until #138 is merged


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My change is a source code change
  - [ ] I have added/modified tests to cover my changes
  - [ ] I have explained why my change does not require new/modified tests 
- [x] All new and existing tests passed.
  - [x] CI tests pass
  - [x] Local tests pass (including Serpent2 integration tests)
- [x] ~I have recorded my changes in the changelog for the upcoming release~ n/a

## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: closes #135


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @munkm 


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
