### PR TITLE
Typo fix in CI

### DIFF
--- a/tools/ci/build-openmc.sh
+++ b/tools/ci/build-openmc.sh
@@ -14,7 +14,7 @@ mkdir openmc_src/include
 
 # Copy libraries to caching folder 
 cp /usr/local/bin/openmc openmc_src/bin/.
-cp -r /usr/local/lib/x86_64-linux-gnu/ openmc_src/lib/.
+cp -r /usr/local/lib/x86_64-linux-gnu openmc_src/lib/.
 cp -r /usr/local/share/openmc openmc_src/share/.
 cp -r /usr/local/share/man openmc_src/share/.
 cp -r /usr/local/include/openmc openmc_src/include/.


### PR DESCRIPTION
## Summary of changes
<!--- In one or more sentences, describe the PR you are submitting -->
This PR is a typo fix in the CI. We are running into the following bug when running the new `Test saltproc` workflow from #153:
```
+ mkdir openmc_src/include
+ cp /usr/local/bin/openmc openmc_src/bin/.
+ cp -r /usr/local/lib/x86_64-linux-gnu/ openmc_src/lib/.
cp: cannot stat '/usr/local/lib/x86_64-linux-gnu/': No such file or directory
Error: Process completed with exit code 1.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Required for Merging
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly. 
- [ ] My change is a source code change
  - [ ] I have added/modified tests to cover my changes
  - [ ] I have explained why my change does not require new/modified tests
- [ ] My change is a user-facing change
  - [ ] I have recorded my changes in the changelog for the upcoming release
- [ ] My change is exclusively related to the repository (e.g. GitHub actions workflows, PR/issue templates, etc.)
  - [ ] I have verified or justified that my change will work as intended.
- [ ] All new and existing tests passed.
  - [ ] CI tests pass
  - [ ] Local tests pass (including Serpent2 integration tests)
## Associated Issues and PRs
<!--- Please note any issues or pull requests associated with this pull request -->

- Issue: #


## Associated Developers
<!--- Please mention any developers who should be alerted of this PR -->

- Dev: @


## Checklist for Reviewers

Reviewers should use [this link](https://arfc.github.io/manual/guides/pull_requests) to get to the 
Review Checklist before they begin their review.
