### PR TITLE
ci: add flake8 linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - 'saltproc/**'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - 'saltproc/**'
+      - 'tests/**'
+
+jobs:
+  flake8:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run flake8
+        run: |
+          flake8 saltproc/ tests/ \
+            --select=E9,F401,F811,F821,F841 \
+            --max-line-length=120 \
+            --show-source \
+            --statistics


### PR DESCRIPTION
Closes #206.

Adds `.github/workflows/lint.yml` — a lightweight GitHub Actions job that runs `flake8` on `saltproc/` and `tests/` whenever either directory changes.

**What it checks** (`--select=E9,F401,F811,F821,F841`):
- `E9` — syntax errors that prevent the file from being parsed
- `F401` — imported but unused modules
- `F811` — redefinition of an unused name
- `F821` — undefined name (would fail at runtime)
- `F841` — assigned but never used local variable

**What it deliberately skips:** stylistic rules (line-length aside from a 120-char cap, whitespace, blank lines) — avoids flagging the existing codebase for conventions that predate this check and keeps the CI fast.

The job uses `actions/setup-python` rather than the conda stack since `flake8` has no scientific dependencies, so it completes in seconds rather than the several minutes the full test matrix takes.