### PR TITLE
fix: wrong nuclide codes for ground-state nuclides + two crashes

### DIFF
--- a/saltproc/openmc_depcode.py
+++ b/saltproc/openmc_depcode.py
@@ -89,7 +89,7 @@ class OpenMCDepcode(Depcode):
         if exec_path == "openmc_deplete.py":
             exec_path = (Path(__file__).parents[0] / exec_path).resolve()
         else:
-            exec_path == (Path(template_input_file_path['settings'].parents[0]) / exec_path).resolve()
+            exec_path = (Path(template_input_file_path['settings'].parents[0]) / exec_path).resolve()
 
         self.depletion_settings = depletion_settings
         self.chain_file_path = chain_file_path

--- a/saltproc/results.py
+++ b/saltproc/results.py
@@ -148,8 +148,8 @@ class Results():
                    len(material.after_reproc.comp))
         material_comp = np.empty(arr_dim)
         for nuc in nucs:
-            nuc_comp_br = material.before_reproc.comp[:, nuc_map[nuc]]
-            nuc_comp_ar = material.after_reproc.comp[:, nuc_map[nuc]]
+            nuc_comp_br = material.before_reproc.comp[:, nuc_map[nuc]].tolist()
+            nuc_comp_ar = material.after_reproc.comp[:, nuc_map[nuc]].tolist()
             nuc_comp_0 = nuc_comp_br.pop(0)
             nuc_comp = []
             for c1, c2 in zip(nuc_comp_br, nuc_comp_ar):

--- a/saltproc/serpent_depcode.py
+++ b/saltproc/serpent_depcode.py
@@ -257,6 +257,8 @@ class SerpentDepcode(Depcode):
                       nuc_code = 95642
                    else:
                       nuc_code = 95242
+        else:
+            nuc_code += a
         return nuc_code
 
 


### PR DESCRIPTION
Three independent fixes found while auditing the depletion code.

### 1. Ground-state nuclides get the wrong ZA code (`serpent_depcode.py`, `_zam_to_nuclide_code`)
```python
def _zam_to_nuclide_code(self, Z, a, m):
    nuc_code = Z * 1000
    if m != 0:
        ...
    return nuc_code
```
For a ground-state nuclide (`m == 0`) the mass number `a` is never added, so e.g. U-235 (`Z=92, a=235`) encodes as `92000` instead of `92235`. The inverse method `_nuclide_code_to_zam` recovers `a = nuc_code % 1000`, confirming the encoding must be `Z*1000 + a`.

I add `a` **only** in the `m == 0` branch. The metastable branches are intentionally left untouched: the `serpent` branch's `((a/100)-3)*100` already carries an `a`-dependent offset, and the `nndc` branch follows its own convention — I didn't want to disturb conventions I'm not certain about. Happy to extend if the metastable paths also need `a`.

### 2. `.pop()` on a NumPy array (`results.py`)
```python
nuc_comp_br = material.before_reproc.comp[:, nuc_map[nuc]]   # ndarray
nuc_comp_0 = nuc_comp_br.pop(0)                              # AttributeError
```
`comp[:, ...]` is a NumPy array with no `.pop`. The sibling method (`_collect_material_properties`) calls `.tolist()` first; added it here for both `before`/`after` arrays.

### 3. `==` instead of `=` (`openmc_depcode.py`)
```python
else:
    exec_path == (Path(...) / exec_path).resolve()
```
The non-default depletion-script branch compares instead of assigns, so the resolved path is computed and discarded and `exec_path` is never updated. Changed to `=`.

### Testing
Localized fixes verified against the surrounding code; I didn't run the suite locally (needs a Serpent/OpenMC environment). Glad to adjust to your conventions.